### PR TITLE
Dockerization & Deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 
+.git
 .github
 .vscode
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+
+.github
+.vscode
+
+npm-debug.log

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: mandobot
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+          else
+            docker build . --file Dockerfile
+          fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker Test & Build
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ build/src/db_config.json
 logs
 
 .vscode
+
+data

--- a/.gitignore
+++ b/.gitignore
@@ -116,4 +116,4 @@ logs
 
 .vscode
 
-data
+secrets.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY package*.json ./
 RUN npm ci --production --silent
 
 # Need specific port enabled
-EXPOSE 4500
+EXPOSE 3500
 
 # Bundle app source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 #Node LTS 12
 FROM node:12
 
+RUN mkdir -p /usr/mando_bot/src
+
 # Set working dir
 WORKDIR /usr/mando_bot/src
 
@@ -8,7 +10,7 @@ WORKDIR /usr/mando_bot/src
 COPY package*.json ./
 
 # Get dependencies
-RUN npm ci --only=production
+RUN npm ci --production --silent
 
 # Need specific port enabled
 EXPOSE 4500
@@ -16,8 +18,5 @@ EXPOSE 4500
 # Bundle app source
 COPY . .
 
-# Build app source
-RUN npm run build
-
 # Start the server
-CMD [ "NODE_ENV=production", "node", "./build/index.js" ]
+CMD [ "node", "./build/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+#Node LTS 12
+FROM node:12
+
+# Set working dir
+WORKDIR /usr/mando_bot/src
+
+# Copy all recorded dependencies
+COPY package*.json ./
+
+# Get dependencies
+RUN npm ci --only=production
+
+# Need specific port enabled
+EXPOSE 4500
+
+# Bundle app source
+COPY . .
+
+# Build app source
+RUN npm run build
+
+# Start the server
+CMD [ "NODE_ENV=production", "node", "./build/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY package*.json ./
 RUN npm ci --production --silent
 
 # Need specific port enabled
-EXPOSE 4500
+# EXPOSE 4500
 
 # Bundle app source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY package*.json ./
 RUN npm ci --production --silent
 
 # Need specific port enabled
-# EXPOSE 4500
+EXPOSE 4500
 
 # Bundle app source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm ci --production --silent
 EXPOSE 3500
 
 # Bundle app source
-COPY . .
+COPY ./build/ .
 
 # Start the server
-CMD [ "node", "./build/index.js" ]
+CMD [ "node", "index.js" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,28 @@
+#Node LTS 12
+FROM node:12
+
+RUN mkdir -p /usr/mando_bot/src
+
+# Set working dir
+WORKDIR /usr/mando_bot/src
+
+# Copy all recorded dependencies
+COPY package*.json ./
+
+# Clean install all dependencies
+RUN npm ci
+
+# Copy all source contents -- will build the js bundle later
+COPY . .
+
+# Build JS bundle
+RUN npm run build
+
+# Copy all recorded dependencies
+COPY package*.json ./build
+
+# Go to builds folder
+WORKDIR /usr/mando_bot/build
+
+# Run all tests
+RUN npm test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,11 +18,5 @@ COPY . .
 # Build JS bundle
 RUN npm run build
 
-# Copy all recorded dependencies
-COPY package*.json ./build
-
-# Go to builds folder
-WORKDIR /usr/mando_bot/build
-
 # Run all tests
-RUN npm test
+CMD ["npm", "run", "test_build"]

--- a/config.env
+++ b/config.env
@@ -1,0 +1,2 @@
+NODE_ENV=production
+PORT=4500

--- a/config.env
+++ b/config.env
@@ -1,2 +1,4 @@
 NODE_ENV=production
 PORT=3500
+SERVER_BINDING=0.0.0.0
+MONGO_CONNECTION_URI="mongodb://mongodb:27017/"

--- a/config.env
+++ b/config.env
@@ -1,2 +1,2 @@
 NODE_ENV=production
-PORT=4500
+PORT=3500

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,4 @@
+sut:
+    build: 
+        context: .
+        dockerfile: Dockerfile.test

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,2 +1,6 @@
-sut:
-    build: ./Dockerfile.test
+version: '3.8'
+services:
+    sut:
+        build: 
+            context: .
+            dockerfile: Dockerfile.test

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,2 @@
 sut:
-    build: 
-        context: .
-        dockerfile: Dockerfile.test
+    build: ./Dockerfile.test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,12 @@ services:
     restart: always
     environment:
       - NODE_ENV="production"
-      - PORT="3500"
-      - SERVER_BINDING="0.0.0.0"                          # For express.js, listen to all
+      - PORT=3500
+      - SERVER_BINDING=0.0.0.0                          # For express.js, listen to all
       - MONGO_CONNECTION_URI="mongodb://mongodb:27017/"   # Connection URL must match name of mongo container
     build: ./
     ports:
-      - target: 3500
-        published: 3500
-        protocol: tcp
-        mode: host
+      - 3500:3500
     links:
       - mongo
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: "3.8" # https://docs.docker.com/compose/compose-file/
 services:
   app:
     container_name: mando_bot
-    restart: always
-    env_file: ./config.env
+    restart: unless-stopped
+    environment:
+      - NODE_ENV="production"
+      - PORT="4500"
     build: ./
     ports:
       - "4500:4500"
@@ -12,6 +14,7 @@ services:
   mongo:
     container_name: mongo
     image: mongo
+    restart: unless-stopped
     volumes:
       - ./data:/data/db
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   app:
     container_name: mando_bot
     restart: always
+    env_file: 
+      - config.env
+      - secrets.env
     environment:
-      - NODE_ENV="production"
-      - PORT=3500
-      - SERVER_BINDING=0.0.0.0                          # For express.js, listen to all
       - MONGO_CONNECTION_URI="mongodb://mongodb:27017/"   # Connection URL must match name of mongo container
     build: ./
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,20 +2,23 @@ version: "3.8" # https://docs.docker.com/compose/compose-file/
 services:
   app:
     container_name: mando_bot
-    restart: unless-stopped
+    restart: always
     environment:
       - NODE_ENV="production"
       - PORT="4500"
+      - MONGO_CONNECTION_URI="mongodb://mongodb:27017/"
     build: ./
     ports:
       - "4500:4500"
     links:
       - mongo
   mongo:
-    container_name: mongo
-    image: mongo
-    restart: unless-stopped
+    container_name: mongodb
+    image: mongo:latest
+    restart: always
     volumes:
-      - ./data:/data/db
+      - mongodata:/data/db
     ports:
       - "27017:27017"
+volumes:
+  mongodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     environment:
       - NODE_ENV="production"
       - PORT="4500"
-      - MONGO_CONNECTION_URI="mongodb://mongodb:27017/"
+      - SERVER_BINDING="0.0.0.0"                          # For express.js, listen to all
+      - MONGO_CONNECTION_URI="mongodb://mongodb:27017/"   # Connection URL must match name of mongo container
     build: ./
     ports:
       - "4500:4500"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,18 @@ services:
     restart: always
     environment:
       - NODE_ENV="production"
-      - PORT="4500"
+      - PORT="3500"
       - SERVER_BINDING="0.0.0.0"                          # For express.js, listen to all
       - MONGO_CONNECTION_URI="mongodb://mongodb:27017/"   # Connection URL must match name of mongo container
     build: ./
     ports:
-      - "4500:4500"
+      - target: 3500
+        published: 3500
+        protocol: tcp
+        mode: host
     links:
+      - mongo
+    depends_on:
       - mongo
   mongo:
     container_name: mongodb
@@ -20,6 +25,6 @@ services:
     volumes:
       - mongodata:/data/db
     ports:
-      - "27017:27017"
+      - "27018:27017"
 volumes:
   mongodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.8" # https://docs.docker.com/compose/compose-file/
+services:
+  app:
+    container_name: mando_bot
+    restart: always
+    env_file: ./config.env
+    build: ./
+    ports:
+      - "4500:4500"
+    links:
+      - mongo
+  mongo:
+    container_name: mongo
+    image: mongo
+    volumes:
+      - ./data:/data/db
+    ports:
+      - "27017:27017"

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,8 @@ import AppConfig from "./src/utils/AppConfig";
 import EventHandler from "./src/handlers/events/Event.handler";
 
 const app = express()
-const PORT = process.env.PORT || 3500;
+const PORT = (process.env.PORT || 3500) as number;
+const BINDING = process.env.SERVER_BINDING || "127.0.0.1";
 
 const ALLOW_TOKEN = AppConfig.VERIFICATION_TOKEN;
 
@@ -42,6 +43,7 @@ app.post('*', (req, res) => {
 	}
 });
 
-app.listen(PORT, async () => {
+app.listen(PORT, BINDING, async () => {
 	logger.info(`Mando Bot listening on port ${PORT}!`);
+	logger.info(`Listening on binding URL: ${BINDING}.`)
 });

--- a/index.ts
+++ b/index.ts
@@ -7,9 +7,10 @@ import EventHandler from "./src/handlers/events/Event.handler";
 
 const app = express()
 const PORT = (process.env.PORT || 3500) as number;
-const BINDING = process.env.SERVER_BINDING || "127.0.0.1";
+const HOST = process.env.SERVER_BINDING || "127.0.0.1";
 
 const ALLOW_TOKEN = AppConfig.VERIFICATION_TOKEN;
+logger.debug(`Using verification token ${ALLOW_TOKEN}`)
 
 var bodyParser = require('body-parser');
 app.use(bodyParser.json());
@@ -43,7 +44,5 @@ app.post('*', (req, res) => {
 	}
 });
 
-app.listen(PORT, BINDING, async () => {
-	logger.info(`Mando Bot listening on port ${PORT}!`);
-	logger.info(`Listening on binding URL: ${BINDING}.`)
-});
+app.listen(PORT, HOST);
+logger.info(`Running on http://${HOST}:${PORT}`);

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ const PORT = (process.env.PORT || 3500) as number;
 const HOST = process.env.SERVER_BINDING || "127.0.0.1";
 
 const ALLOW_TOKEN = AppConfig.VERIFICATION_TOKEN;
-logger.debug(`Using verification token ${ALLOW_TOKEN}`)
+logger.info(`Using verification token ${ALLOW_TOKEN}`)
 
 var bodyParser = require('body-parser');
 app.use(bodyParser.json());

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
@@ -228,8 +227,7 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-      "dev": true
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asn1": {
       "version": "0.2.4",
@@ -323,7 +321,6 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-      "dev": true,
       "requires": {
         "bytes": "3.1.0",
         "content-type": "~1.0.4",
@@ -361,8 +358,7 @@
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-      "dev": true
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "camelcase": {
       "version": "2.1.1",
@@ -483,7 +479,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -491,20 +486,17 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "dev": true
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -559,7 +551,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -583,14 +574,12 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diagnostics": {
       "version": "1.1.1",
@@ -629,8 +618,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "enabled": {
       "version": "1.0.2",
@@ -643,8 +631,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "env-variable": {
       "version": "0.0.5",
@@ -663,14 +650,12 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "dev": true
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "execa": {
       "version": "0.7.0",
@@ -691,7 +676,6 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-      "dev": true,
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -768,7 +752,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -808,14 +791,12 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "dev": true
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -899,7 +880,6 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -922,7 +902,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -960,8 +939,7 @@
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1208,8 +1186,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
       "version": "1.1.0",
@@ -1247,20 +1224,17 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.43.0",
@@ -1392,8 +1366,7 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "dev": true
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "node-cron": {
       "version": "2.0.3",
@@ -1459,7 +1432,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -1536,8 +1508,7 @@
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-exists": {
       "version": "2.1.0",
@@ -1569,8 +1540,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-      "dev": true
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "1.1.0",
@@ -1618,7 +1588,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
       "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
-      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
@@ -1643,20 +1612,17 @@
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-      "dev": true
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-      "dev": true,
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.2",
@@ -1840,7 +1806,6 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -1860,8 +1825,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -1869,7 +1833,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -1886,8 +1849,7 @@
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-      "dev": true
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -2022,8 +1984,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
       "version": "2.1.1",
@@ -2120,8 +2081,7 @@
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "2.4.3",
@@ -2231,7 +2191,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -2251,8 +2210,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -2270,8 +2228,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.3.3",
@@ -2291,8 +2248,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "mongoose-unique-validator": "^2.0.3",
     "node-cron": "^2.0.3",
     "request": "^2.88.0",
-    "winston": "^3.2.1"
+    "winston": "^3.2.1",
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "npm run dev",
     "test": "jasmine-ts \"spec/**/*.spec.ts\"",
+    "test_build": "jasmine-ts \"build/spec/**/*.spec.js\"",
     "tsc": "tsc",
     "dev": "ts-node-dev --respawn --transpileOnly index.ts",
     "build": "tsc && cp -r src/config/ ./build/src"

--- a/scripts/mb_down.sh
+++ b/scripts/mb_down.sh
@@ -1,0 +1,2 @@
+# Stop and remove MandoBot stack
+docker-compose down --remove-orphans

--- a/scripts/mb_up.sh
+++ b/scripts/mb_up.sh
@@ -1,0 +1,2 @@
+docker-compose build
+docker-compose up

--- a/scripts/mb_up.sh
+++ b/scripts/mb_up.sh
@@ -1,2 +1,2 @@
-docker-compose build
-docker-compose up
+# Build & start MandoBot stack
+docker-compose up -d --build

--- a/src/initializers/mongo.ts
+++ b/src/initializers/mongo.ts
@@ -4,16 +4,13 @@ import * as config from '../config/db_config.json';
 
 /** Initialize connection to database */
 export default async function main(): Promise<void> {
-    const url = config.mongo_db.url + config.mongo_db.database;
+    const url = (process.env.MONGO_CONNECTION_URI || config.mongo_db.url) + config.mongo_db.database;
     const options = { useNewUrlParser: true, useUnifiedTopology: true };
     
     Logger.info("Connecting to db...");
 
     await mongoose.connect(url, options);
-
-    const db = mongoose.connection;
-    db.on('error', errorCallback);
-    db.once('open', successCallback);
+    Logger.info("Connected to db!");
 }
 
 /** If connection to db is not possible due to error. */

--- a/src/initializers/mongo.ts
+++ b/src/initializers/mongo.ts
@@ -6,6 +6,8 @@ import * as config from '../config/db_config.json';
 export default async function main(): Promise<void> {
     const url = config.mongo_db.url + config.mongo_db.database;
     const options = { useNewUrlParser: true, useUnifiedTopology: true };
+    
+    Logger.info("Connecting to db...");
 
     await mongoose.connect(url, options);
 

--- a/src/jobs/channel_updater/UpdateChannels.ts
+++ b/src/jobs/channel_updater/UpdateChannels.ts
@@ -6,6 +6,9 @@ import ChannelHelper from "../../models/Channel/Channel.helper";
 export default class ChannelUpdater extends BackgroundJob {
     constructor() { super(); }
 
+    /** Update list of all available channels
+     * @override
+     */
     public async perform(): Promise<void> {
         JobLogger.info("Starting refresh of list of channels.");
 

--- a/src/jobs/user_updater/UpdateUsers.ts
+++ b/src/jobs/user_updater/UpdateUsers.ts
@@ -6,6 +6,9 @@ import UserHelper from "../../models/User/User.helper";
 export default class UserUpdater extends BackgroundJob {
     constructor() { super(); }
 
+    /** Update list of all users
+     * @override
+     */
     public async perform(): Promise<void> {
         JobLogger.info("Starting update of all users.");
         let users = (await GetListOfAllUsers() as any[]).filter(user => { return !user.is_bot });

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -50,7 +50,7 @@ export const JobLogger = winston.createLogger({
                 format: winston.format.combine(
                     winston.format.timestamp(),
                     winston.format.simple(),
-                    winston.format.printf(msg => `[${msg.timestamp}] ${msg.level.toUpperCase()}: ${msg.message}`)
+                    winston.format.printf(msg => `[${msg.timestamp}] CRON-${msg.level.toUpperCase()}: ${msg.message}`)
                     ),
             }
         ),


### PR DESCRIPTION
Dockerized the slack bot. Using `docker-compose` it will instantiate two linked containers, one for MongoDB and another for the slack bot. 

To start the application:
1. Give executable permissions `chmod +x ./scripts/mb_up.sh`
2. Run `./scripts/mb_up.sh`

Also includes the introduction of Environment variables when building the docker image. A file `secrets.env` **is required** in the root directory when building the image. It must contain both `MANDO_SLACK_TOKEN` and `MANDO_BOT_TOKEN` (refer to README).

Fixes:
* Issue where express.js was not installed when downloading production dependencies only
* Change how logger errors when connecting to db appear
* override mongodb connection URL as environment variable
* other minor fixes/improvements